### PR TITLE
Fix NPE issue when a @Join field is null.

### DIFF
--- a/source/src/main/java/siena/gae/GaePersistenceManager.java
+++ b/source/src/main/java/siena/gae/GaePersistenceManager.java
@@ -211,7 +211,13 @@ public class GaePersistenceManager extends AbstractPersistenceManager {
 			// creates the list of joined entity keys to extract 
 			for (final T model : models) {
 				for(Field field: fieldMap.keySet()){
-					Key key = GaeMappingUtils.getKey(field.get(model));
+                    Object objVal = field.get(model);
+                    // our object is not linked to another object...so it doesn't have any key
+                    if(objVal == null) {
+                        continue;
+                    }
+
+                    Key key = GaeMappingUtils.getKey(objVal);
 					List<Key> keys = fieldMap.get(field);
 					if(!keys.contains(key))
 						keys.add(key);
@@ -240,6 +246,10 @@ public class GaePersistenceManager extends AbstractPersistenceManager {
 			for (final T model : models) {
 				for(Field field: fieldMap.keySet()){
 					Object objVal = field.get(model);
+                    if(objVal == null) {
+                        continue;
+                    }
+
 					Key key = GaeMappingUtils.getKey(objVal);
 					linkedObj = linkedModels.get(key);
 					if(linkedObj==null){

--- a/source/src/test/java/siena/base/test/GaeTest.java
+++ b/source/src/test/java/siena/base/test/GaeTest.java
@@ -8,6 +8,7 @@ import siena.Query;
 import siena.SienaException;
 import siena.SienaRestrictedApiException;
 import siena.base.test.model.Discovery;
+import siena.base.test.model.Discovery4Join;
 import siena.base.test.model.Discovery4Search;
 import siena.base.test.model.PersonUUID;
 import siena.gae.GaePersistenceManager;
@@ -71,7 +72,18 @@ public class GaeTest extends BaseTest {
 		
 		fail();
 	}
-	
+
+
+    public void testInsertObjectWithNullJoinObject() {
+        Discovery4Join model = new Discovery4Join();
+        model.discovererJoined = null; // explicitly set the join object to null
+
+        pm.insert(model);
+
+        Query<Discovery4Join> query = pm.createQuery(Discovery4Join.class).filter("id", model.id);
+        Discovery4Join modelFromDatabase = pm.get(query);
+        assertNull(modelFromDatabase.discovererJoined);
+    }
 	
 	public void testFilterWithOperatorINStateful() {
 		List<PersonUUID> l = getOrderedPersonUUIDs();


### PR DESCRIPTION
fix an issue about @Join : when the field with the @Join is null, the GAE key is not computed and so you don't get an NPE
