### PR TITLE
Wrong boolean value decoding

### DIFF
--- a/source/src/main/java/siena/Util.java
+++ b/source/src/main/java/siena/Util.java
@@ -228,7 +228,7 @@ public class Util {
 			else if(Long.TYPE==type || Long.class==type)    return number.longValue();
 			else if(Float.TYPE==type || Float.class==type)   return number.floatValue();
 			else if(Double.TYPE==type || Double.class==type)  return number.doubleValue();
-			else if(Boolean.TYPE==type || Boolean.class==type) return number!=(Number)0 ? true:false;
+			else if(Boolean.TYPE==type || Boolean.class==type) return number.byteValue() != 0;
 			else if(BigDecimal.class==type) return (BigDecimal)value;
 		} 
 		

--- a/source/src/test/java/siena/base/test/BaseTest.java
+++ b/source/src/test/java/siena/base/test/BaseTest.java
@@ -1445,7 +1445,7 @@ public abstract class BaseTest extends TestCase {
 		assertEqualsDataTypes(dataTypes, same);
 	}
 	
-	private void assertEqualsDataTypes(DataTypes dataTypes, DataTypes same) {
+	protected void assertEqualsDataTypes(DataTypes dataTypes, DataTypes same) {
 		assertEquals(dataTypes.id, same.id);
 		assertEquals(dataTypes.typeByte, same.typeByte);
 		assertEquals(dataTypes.typeShort, same.typeShort);

--- a/source/src/test/java/siena/base/test/H2Test.java
+++ b/source/src/test/java/siena/base/test/H2Test.java
@@ -2,8 +2,7 @@ package siena.base.test;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
-import java.util.List;
-import java.util.Properties;
+import java.util.*;
 
 import org.apache.commons.dbcp.BasicDataSource;
 import org.apache.ddlutils.Platform;
@@ -13,12 +12,12 @@ import org.h2.jdbcx.JdbcDataSource;
 
 import siena.PersistenceManager;
 import siena.Query;
-import siena.base.test.model.Discovery4Search;
-import siena.base.test.model.Discovery4Search2;
-import siena.base.test.model.TextModel;
+import siena.base.test.model.*;
 import siena.jdbc.H2PersistenceManager;
 import siena.jdbc.PostgresqlPersistenceManager;
 import siena.jdbc.ddl.DdlGenerator;
+
+import static siena.Json.map;
 
 public class H2Test extends BaseTest {
 	private static H2PersistenceManager pm;
@@ -810,6 +809,19 @@ public class H2Test extends BaseTest {
 		// TODO Auto-generated method stub
 		super.testDataTypesNotNull();
 	}
+
+    public void testDataTypesNotNullWithANotherBoolean() {
+        DataTypes dataTypes = new DataTypes();
+        dataTypes.boolBool = Boolean.FALSE;
+
+        pm.insert(dataTypes);
+
+        // to test that fields are read back correctly
+        pm.createQuery(DataTypes.class).filter("id", dataTypes.id).get();
+
+        DataTypes same = pm.createQuery(DataTypes.class).get();
+        assertEqualsDataTypes(dataTypes, same);
+    }
 
 	@Override
 	public void testQueryDelete() {

--- a/source/src/test/java/siena/core/test/TestUtil.java
+++ b/source/src/test/java/siena/core/test/TestUtil.java
@@ -15,6 +15,7 @@
  */
 package siena.core.test;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 
@@ -34,5 +35,19 @@ public class TestUtil extends TestCase {
 		assertEquals("5de5f7ed4762f3e6555f479d98a75696170c1eb1", Util.sha1("siena"));
 		assertEquals("622758a4191a450e0d94ad07b6d9d8ef67ffc485", Util.sha1("ma\u00f1o"));
 	}
+    
+    public Boolean booleanField = false;
+    
+    public void testFromObjectWithBoolean() {
+        byte zero = 0;
+        byte one = 1;
+
+        Field field = Util.getField(TestUtil.class, "booleanField");
+        Boolean result = (Boolean) Util.fromObject(field, zero);
+        assertFalse(result);
+
+        result = (Boolean) Util.fromObject(field, one);
+        assertTrue(result);
+    }
 
 }


### PR DESCRIPTION
`Util.fromObject` wasn't correctly  decoding boolean value : 0 value was decoded as true, instead of false due to a test by reference, despite a check by value.

Issue seen on a playframework project and an H2 Database.
