### PR TITLE
implemented sticky options for PM

### DIFF
--- a/source/pom.xml
+++ b/source/pom.xml
@@ -351,7 +351,7 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpcore</artifactId>
-			<version>4.1.1</version>
+			<version>4.2.1</version>
 		</dependency>
 	</dependencies>
 

--- a/source/src/main/java/siena/core/options/PmOptionStickiness.java
+++ b/source/src/main/java/siena/core/options/PmOptionStickiness.java
@@ -1,0 +1,14 @@
+package siena.core.options;
+
+public enum PmOptionStickiness
+{
+    /**
+     * option is set globally (for the PM instance)
+     */
+	STICKY,
+	
+	/**
+	 * option is set only for the thread context
+	 */
+	NOT_STICKY
+}

--- a/source/src/test/java/siena/base/test/SDBTestNoAutoInc_10_TRANSACTION.java
+++ b/source/src/test/java/siena/base/test/SDBTestNoAutoInc_10_TRANSACTION.java
@@ -13,19 +13,8 @@ public class SDBTestNoAutoInc_10_TRANSACTION extends BaseTestNoAutoInc_10_TRANSA
 	public PersistenceManager createPersistenceManager(List<Class<?>> classes)
 			throws Exception {
 		
-		Properties p = new Properties();
-		// don't want to give my AWS ID/secrets :D
-	    //p.load(new FileInputStream("/home/pascal/work/mandubian/aws/siena-aws.properties"));
-		p.load(new FileInputStream("/home/mandubian/work/aws/siena-aws.properties"));
-
-		
-		//p.setProperty("implementation", "siena.sdb.SdbPersistenceManager");
-		//p.setProperty("awsAccessKeyId", "");
-		//p.setProperty("awsSecretAccessKey", "");
-		//p.setProperty("prefix", "siena_devel_");
-		
 		SdbPersistenceManager sdb = new SdbPersistenceManager();
-		sdb.init(p);
+		sdb.init(SimpleDBConfig.getSienaAWSProperties());
 		
 		return sdb;
 	}

--- a/source/src/test/java/siena/base/test/SDBTestNoAutoInc_1_CRUD.java
+++ b/source/src/test/java/siena/base/test/SDBTestNoAutoInc_1_CRUD.java
@@ -17,21 +17,8 @@ public class SDBTestNoAutoInc_1_CRUD extends BaseTestNoAutoInc_1_CRUD {
 	@Override
 	public PersistenceManager createPersistenceManager(List<Class<?>> classes)
 			throws Exception {
-		
-		Properties p = new Properties();
-		// don't want to give my AWS ID/secrets :D
-	    //p.load(new FileInputStream("/home/pascal/work/mandubian/aws/siena-aws.properties"));
-		p.load(new FileInputStream("/home/mandubian/work/aws/siena-aws.properties"));
-		
-		
-		//p.setProperty("implementation", "siena.sdb.SdbPersistenceManager");
-		//p.setProperty("awsAccessKeyId", "");
-		//p.setProperty("awsSecretAccessKey", "");
-		//p.setProperty("prefix", "siena_devel_");
-		
 		SdbPersistenceManager sdb = new SdbPersistenceManager();
-		sdb.init(p);
-		
+		sdb.init(SimpleDBConfig.getSienaAWSProperties());
 		return sdb;
 	}
 

--- a/source/src/test/java/siena/base/test/SDBTestNoAutoInc_2_FETCH.java
+++ b/source/src/test/java/siena/base/test/SDBTestNoAutoInc_2_FETCH.java
@@ -13,20 +13,8 @@ public class SDBTestNoAutoInc_2_FETCH extends BaseTestNoAutoInc_2_FETCH {
 	public PersistenceManager createPersistenceManager(List<Class<?>> classes)
 			throws Exception {
 		
-		Properties p = new Properties();
-		// don't want to give my AWS ID/secrets :D
-	    //p.load(new FileInputStream("/home/pascal/work/mandubian/aws/siena-aws.properties"));
-		p.load(new FileInputStream("/home/mandubian/work/aws/siena-aws.properties"));
-
-		
-		//p.setProperty("implementation", "siena.sdb.SdbPersistenceManager");
-		//p.setProperty("awsAccessKeyId", "");
-		//p.setProperty("awsSecretAccessKey", "");
-		//p.setProperty("prefix", "siena_devel_");
-		
 		SdbPersistenceManager sdb = new SdbPersistenceManager();
-		sdb.init(p);
-		
+		sdb.init(SimpleDBConfig.getSienaAWSProperties());
 		return sdb;
 	}
 

--- a/source/src/test/java/siena/base/test/SDBTestNoAutoInc_3_ITER.java
+++ b/source/src/test/java/siena/base/test/SDBTestNoAutoInc_3_ITER.java
@@ -18,20 +18,8 @@ public class SDBTestNoAutoInc_3_ITER extends BaseTestNoAutoInc_3_ITER {
 	public PersistenceManager createPersistenceManager(List<Class<?>> classes)
 			throws Exception {
 		
-		Properties p = new Properties();
-		// don't want to give my AWS ID/secrets :D
-	    //p.load(new FileInputStream("/home/pascal/work/mandubian/aws/siena-aws.properties"));
-		p.load(new FileInputStream("/home/mandubian/work/aws/siena-aws.properties"));
-
-		
-		//p.setProperty("implementation", "siena.sdb.SdbPersistenceManager");
-		//p.setProperty("awsAccessKeyId", "");
-		//p.setProperty("awsSecretAccessKey", "");
-		//p.setProperty("prefix", "siena_devel_");
-		
 		SdbPersistenceManager sdb = new SdbPersistenceManager();
-		sdb.init(p);
-		
+		sdb.init(SimpleDBConfig.getSienaAWSProperties());
 		return sdb;
 	}
 

--- a/source/src/test/java/siena/base/test/SDBTestNoAutoInc_4_SPECIALS.java
+++ b/source/src/test/java/siena/base/test/SDBTestNoAutoInc_4_SPECIALS.java
@@ -18,20 +18,8 @@ public class SDBTestNoAutoInc_4_SPECIALS extends BaseTestNoAutoInc_4_SPECIALS {
 	public PersistenceManager createPersistenceManager(List<Class<?>> classes)
 			throws Exception {
 		
-		Properties p = new Properties();
-		// don't want to give my AWS ID/secrets :D
-	    //p.load(new FileInputStream("/home/pascal/work/mandubian/aws/siena-aws.properties"));
-		p.load(new FileInputStream("/home/mandubian/work/aws/siena-aws.properties"));
-
-		
-		//p.setProperty("implementation", "siena.sdb.SdbPersistenceManager");
-		//p.setProperty("awsAccessKeyId", "");
-		//p.setProperty("awsSecretAccessKey", "");
-		//p.setProperty("prefix", "siena_devel_");
-		
 		SdbPersistenceManager sdb = new SdbPersistenceManager();
-		sdb.init(p);
-		
+		sdb.init(SimpleDBConfig.getSienaAWSProperties());
 		return sdb;
 	}
 

--- a/source/src/test/java/siena/base/test/SDBTestNoAutoInc_5_PAGINATE.java
+++ b/source/src/test/java/siena/base/test/SDBTestNoAutoInc_5_PAGINATE.java
@@ -18,19 +18,8 @@ public class SDBTestNoAutoInc_5_PAGINATE extends BaseTestNoAutoInc_5_PAGINATE {
 	public PersistenceManager createPersistenceManager(List<Class<?>> classes)
 			throws Exception {
 		
-		Properties p = new Properties();
-		// don't want to give my AWS ID/secrets :D
-	    //p.load(new FileInputStream("/home/pascal/work/mandubian/aws/siena-aws.properties"));
-		p.load(new FileInputStream("/home/mandubian/work/aws/siena-aws.properties"));
-
-		
-		//p.setProperty("implementation", "siena.sdb.SdbPersistenceManager");
-		//p.setProperty("awsAccessKeyId", "");
-		//p.setProperty("awsSecretAccessKey", "");
-		//p.setProperty("prefix", "siena_devel_");
-		
 		SdbPersistenceManager sdb = new SdbPersistenceManager();
-		sdb.init(p);
+		sdb.init(SimpleDBConfig.getSienaAWSProperties());
 		
 		return sdb;
 	}

--- a/source/src/test/java/siena/base/test/SDBTestNoAutoInc_6_FETCH_ITER.java
+++ b/source/src/test/java/siena/base/test/SDBTestNoAutoInc_6_FETCH_ITER.java
@@ -18,20 +18,8 @@ public class SDBTestNoAutoInc_6_FETCH_ITER extends BaseTestNoAutoInc_6_FETCH_ITE
 	public PersistenceManager createPersistenceManager(List<Class<?>> classes)
 			throws Exception {
 		
-		Properties p = new Properties();
-		// don't want to give my AWS ID/secrets :D
-	    //p.load(new FileInputStream("/home/pascal/work/mandubian/aws/siena-aws.properties"));
-		p.load(new FileInputStream("/home/mandubian/work/aws/siena-aws.properties"));
-
-		
-		//p.setProperty("implementation", "siena.sdb.SdbPersistenceManager");
-		//p.setProperty("awsAccessKeyId", "");
-		//p.setProperty("awsSecretAccessKey", "");
-		//p.setProperty("prefix", "siena_devel_");
-		
 		SdbPersistenceManager sdb = new SdbPersistenceManager();
-		sdb.init(p);
-		
+		sdb.init(SimpleDBConfig.getSienaAWSProperties());
 		return sdb;
 	}
 

--- a/source/src/test/java/siena/base/test/SDBTestNoAutoInc_7_BATCH.java
+++ b/source/src/test/java/siena/base/test/SDBTestNoAutoInc_7_BATCH.java
@@ -13,18 +13,8 @@ public class SDBTestNoAutoInc_7_BATCH extends BaseTestNoAutoInc_7_BATCH {
 	public PersistenceManager createPersistenceManager(List<Class<?>> classes)
 			throws Exception {
 		
-		Properties p = new Properties();
-		// don't want to give my AWS ID/secrets :D
-	    //p.load(new FileInputStream("/home/pascal/work/mandubian/aws/siena-aws.properties"));
-		p.load(new FileInputStream("/home/mandubian/work/aws/siena-aws.properties"));
-
-		//p.setProperty("implementation", "siena.sdb.SdbPersistenceManager");
-		//p.setProperty("awsAccessKeyId", "");
-		//p.setProperty("awsSecretAccessKey", "");
-		//p.setProperty("prefix", "siena_devel_");
-		
 		SdbPersistenceManager sdb = new SdbPersistenceManager();
-		sdb.init(p);
+		sdb.init(SimpleDBConfig.getSienaAWSProperties());
 		
 		return sdb;
 	}

--- a/source/src/test/java/siena/base/test/SDBTestNoAutoInc_8_SEARCH.java
+++ b/source/src/test/java/siena/base/test/SDBTestNoAutoInc_8_SEARCH.java
@@ -13,18 +13,8 @@ public class SDBTestNoAutoInc_8_SEARCH extends BaseTestNoAutoInc_8_SEARCH {
 	public PersistenceManager createPersistenceManager(List<Class<?>> classes)
 			throws Exception {
 		
-		Properties p = new Properties();
-		// don't want to give my AWS ID/secrets :D
-	    //p.load(new FileInputStream("/home/pascal/work/mandubian/aws/siena-aws.properties"));
-		p.load(new FileInputStream("/home/mandubian/work/aws/siena-aws.properties"));
-
-		//p.setProperty("implementation", "siena.sdb.SdbPersistenceManager");
-		//p.setProperty("awsAccessKeyId", "");
-		//p.setProperty("awsSecretAccessKey", "");
-		//p.setProperty("prefix", "siena_devel_");
-		
 		SdbPersistenceManager sdb = new SdbPersistenceManager();
-		sdb.init(p);
+		sdb.init(SimpleDBConfig.getSienaAWSProperties());
 		
 		return sdb;
 	}

--- a/source/src/test/java/siena/base/test/SDBTestNoAutoInc_9_FETCH_ITER_PAGINATE.java
+++ b/source/src/test/java/siena/base/test/SDBTestNoAutoInc_9_FETCH_ITER_PAGINATE.java
@@ -13,18 +13,8 @@ public class SDBTestNoAutoInc_9_FETCH_ITER_PAGINATE extends BaseTestNoAutoInc_9_
 	public PersistenceManager createPersistenceManager(List<Class<?>> classes)
 			throws Exception {
 		
-		Properties p = new Properties();
-		// don't want to give my AWS ID/secrets :D
-	    //p.load(new FileInputStream("/home/pascal/work/mandubian/aws/siena-aws.properties"));
-		p.load(new FileInputStream("/home/mandubian/work/aws/siena-aws.properties"));
-
-		//p.setProperty("implementation", "siena.sdb.SdbPersistenceManager");
-		//p.setProperty("awsAccessKeyId", "");
-		//p.setProperty("awsSecretAccessKey", "");
-		//p.setProperty("prefix", "siena_devel_");
-		
 		SdbPersistenceManager sdb = new SdbPersistenceManager();
-		sdb.init(p);
+		sdb.init(SimpleDBConfig.getSienaAWSProperties());
 		
 		return sdb;
 	}

--- a/source/src/test/java/siena/base/test/SDBTestOption.java
+++ b/source/src/test/java/siena/base/test/SDBTestOption.java
@@ -1,0 +1,97 @@
+package siena.base.test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import junit.framework.TestCase;
+import siena.PersistenceManager;
+import siena.PersistenceManagerFactory;
+import siena.sdb.SdbPersistenceManager;
+import siena.core.options.PmOption;
+import siena.core.options.PmOptionStickiness;
+import siena.sdb.PmOptionSdbReadConsistency;
+
+public abstract class SDBTestOption extends TestCase {
+	
+	protected SdbPersistenceManager sdb;
+
+	List<Class<?>> classes = new ArrayList<Class<?>>();
+
+	public abstract void init();
+	public abstract void createClasses(List<Class<?>> classes);
+	public abstract PersistenceManager createPersistenceManager(List<Class<?>> classes) throws Exception;
+	public abstract void postInit();
+
+	public abstract boolean supportsAutoincrement();
+	public abstract boolean supportsMultipleKeys();
+	public abstract boolean supportsDeleteException();
+	public abstract boolean supportsSearchStart();
+	public abstract boolean supportsSearchEnd();
+	public abstract boolean supportsTransaction();
+	public abstract boolean supportsListStore();
+
+	@Override
+	protected void setUp() throws Exception {
+		super.setUp();
+		
+		sdb = new SdbPersistenceManager();
+		sdb.init(SimpleDBConfig.getSienaAWSProperties());
+	}
+	
+	public void testNonSticky()
+	{
+		PmOption opt;
+		opt = sdb.option(PmOptionSdbReadConsistency.ID);
+		assertTrue(opt == null);
+		
+		sdb.option(SdbPersistenceManager.CONSISTENT_READ);
+		opt = sdb.option(PmOptionSdbReadConsistency.ID);
+		assertTrue(opt != null);
+		assertTrue(opt instanceof PmOptionSdbReadConsistency);
+		
+		assertEquals(SdbPersistenceManager.CONSISTENT_READ, opt);
+	
+	}
+	
+	public void testLocalPriority()
+	{
+		PmOption opt;
+		
+		sdb.option(SdbPersistenceManager.NOT_CONSISTENT_READ, PmOptionStickiness.NOT_STICKY);
+		sdb.option(SdbPersistenceManager.CONSISTENT_READ, PmOptionStickiness.STICKY);
+		opt = sdb.option(PmOptionSdbReadConsistency.ID);
+		assertTrue(opt != null);
+		assertTrue(opt instanceof PmOptionSdbReadConsistency);
+		
+		assertEquals(SdbPersistenceManager.NOT_CONSISTENT_READ, opt);
+	
+	}
+	
+	public void testThread() throws java.lang.InterruptedException
+	{
+		sdb.option(SdbPersistenceManager.CONSISTENT_READ, PmOptionStickiness.STICKY);
+
+	    MyOptionRunner r = new MyOptionRunner(sdb, true);
+		Thread t = new Thread(r);
+		t.start();
+		t.wait(1000);
+	}
+	
+	private class MyOptionRunner implements Runnable
+	{
+		public MyOptionRunner(SdbPersistenceManager sdb, boolean isReadConsistent)
+		{
+			m_sdb = sdb;
+			this.isReadConsistent = isReadConsistent;
+		}
+		
+		public void run() {
+			
+			assertEquals(isReadConsistent,  m_sdb.isReadConsistent());
+		}
+		
+		private SdbPersistenceManager m_sdb;
+		private boolean isReadConsistent;
+	}
+
+}

--- a/source/src/test/java/siena/base/test/SimpleDBConfig.java
+++ b/source/src/test/java/siena/base/test/SimpleDBConfig.java
@@ -1,0 +1,19 @@
+package siena.base.test;
+
+import java.io.InputStream;
+import java.io.FileInputStream;
+import java.util.Properties;
+
+public class SimpleDBConfig {
+
+    public static Properties getSienaAWSProperties() throws java.io.IOException
+    {
+    	Properties p = new Properties();
+    	InputStream is = null;
+    	//is = new FileInputStream("/Users/gregorymaertens/sienaaws.properties");
+    	is = new FileInputStream("/home/mandubian/work/aws/siena-aws.properties");
+	    p.load(is);
+    	return p;
+    }
+	
+}


### PR DESCRIPTION
implemented sticky options for PM. It allows to have options stick for
PM when used across different thread. Previous implementation used
ThreadLocal, so options were valid only in the Thread scope.
The new implementation gives control when setting options to make them
sticky (global scope) or not (thread scope).
refactored unit test to centralize the AWS property file.

In reference to https://groups.google.com/forum/?fromgroups#!topic/siena-discuss/xBmrcUk0V7U
